### PR TITLE
Updated Friek

### DIFF
--- a/data/users.yml
+++ b/data/users.yml
@@ -108,10 +108,7 @@ joris:
   companies: []
 Friek:
   full_name: Johan Mulder
-  rir_handle: JOMU667
   country: nl
-  companies:
-    - cambrium
 Appel:
   full_name: Mark van Herpen
   rir_handle: MvH192-RIPE


### PR DESCRIPTION
Company removed from Friek as well as the RIPE handle. 
No longer working at Cambrium as of 2024-06-01